### PR TITLE
feat: (#3) addition of parserBuilderIter, related parsers and tests

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,7 +1,7 @@
 {
   "semi": true,
   "singleQuote": true,
-  "printWidth": 80,
+  "printWidth": 90,
   "tabWidth": 2,
   "useTabs": true
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,22 @@
 {
   "name": "catch-lib-parser-core",
-  "description": "A library containing core TypeScript parser code for the datr-tech/catch-api",
+  "description": "Core TypeScript parser code for the datr-tech/catch-api",
+  "author": "J.A.Strachan <j.alderson.strachan@datr.tech>",
+  "homepage": "https://github.com/datr-tech/catch-lib-parser-core/",
+  "keywords": [
+    "datr-tech",
+    "catch-api",
+    "parserBuilder",
+    "TypeScript"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/datr-tech/catch-lib-parser-core.git"
+  },
+  "bugs": {
+    "url": "https://github.com/datr-tech/catch-lib-parser-core/issues"
+  },
+  "license": "LGPL-3.0-or-later",
   "version": "0.1.0",
   "main": "./dist/index.mjs",
   "type": "module",

--- a/src/config/enums/ParserTypeEnum.ts
+++ b/src/config/enums/ParserTypeEnum.ts
@@ -1,5 +1,5 @@
 export enum ParserTypeEnum {
 	LEAF = 1,
 	STEM = 2,
-	ITEM = 3,
+	ITER = 3,
 }

--- a/src/core/builders/parserBuilders/index.ts
+++ b/src/core/builders/parserBuilders/index.ts
@@ -1,1 +1,4 @@
 export { parserBuilderCore } from './parserBuilderCore';
+export { parserBuilderIter } from './parserBuilderIter';
+export { parserBuilderLeaf } from './parserBuilderLeaf';
+export { parserBuilderStem } from './parserBuilderStem';

--- a/src/core/builders/parserBuilders/parserBuilderCore.ts
+++ b/src/core/builders/parserBuilders/parserBuilderCore.ts
@@ -1,9 +1,9 @@
 import { IElementChild } from '@app/interfaces/core/builders/parserBuilders/elements';
 import { IParse } from '@app/interfaces/core/builders/parserBuilders/parse';
-import { IParserBuilder } from '@app/interfaces/core/builders/parserBuilders';
+import { IParserBuilderCore } from '@app/interfaces/core/builders/parserBuilders';
 import { assertNonEmptyStr } from '@app/core/assertions';
 
-export const parserBuilderCore: IParserBuilder = ({
+export const parserBuilderCore: IParserBuilderCore = ({
 	elName,
 	parseHandler,
 	parserType,

--- a/src/core/builders/parserBuilders/parserBuilderIter.ts
+++ b/src/core/builders/parserBuilders/parserBuilderIter.ts
@@ -1,0 +1,36 @@
+import { parserBuilderCore } from './parserBuilderCore';
+import { ParserTypeEnum } from '@app/config/enums';
+import {
+	IParseHandler,
+	IParseHandlerOutput,
+} from '@app/interfaces/core/builders/parserBuilders/parseHandlers';
+
+export const parserBuilderIter = ({ childParser }) => {
+	const { elName, parserType } = childParser;
+	const useParent = true;
+
+	if (parserType !== ParserTypeEnum.LEAF && parserType !== ParserTypeEnum.STEM) {
+		throw new TypeError('Use a LEAF or a STEM child parser');
+	}
+
+	const parseHandler: IParseHandler = async ({ el }) => {
+		const childItems: IParseHandlerOutput[] = [];
+
+		for (let i = 0; i < (await el.count()); i++) {
+			const childItem = (await childParser.parse({
+				elParent: el.nth(i),
+				useParent,
+			})) as IParseHandlerOutput;
+
+			childItems.push(childItem);
+		}
+
+		return childItems;
+	};
+
+	return parserBuilderCore({
+		elName,
+		parseHandler,
+		parserType: ParserTypeEnum.ITER,
+	});
+};

--- a/src/core/builders/parserBuilders/parserBuilderLeaf.ts
+++ b/src/core/builders/parserBuilders/parserBuilderLeaf.ts
@@ -1,0 +1,9 @@
+import { parserBuilderCore } from './parserBuilderCore';
+import { ParserTypeEnum } from '@app/config/enums';
+
+export const parserBuilderLeaf = ({ elName, parseHandler }) =>
+	parserBuilderCore({
+		elName,
+		parseHandler,
+		parserType: ParserTypeEnum.LEAF,
+	});

--- a/src/core/builders/parserBuilders/parserBuilderStem.ts
+++ b/src/core/builders/parserBuilders/parserBuilderStem.ts
@@ -1,0 +1,9 @@
+import { parserBuilderCore } from './parserBuilderCore';
+import { ParserTypeEnum } from '@app/config/enums';
+
+export const parserBuilderStem = ({ elName, parseHandler }) =>
+	parserBuilderCore({
+		elName,
+		parseHandler,
+		parserType: ParserTypeEnum.STEM,
+	});

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,29 @@
-export { parserBuilderCore } from './core/builders/parserBuilders';
-export { IParserBuilder } from './interfaces/core/builders/parserBuilders';
+export { ParserTypeEnum } from '@app/config/enums';
+
+export {
+	parserBuilderCore,
+	parserBuilderIter,
+	parserBuilderLeaf,
+	parserBuilderStem,
+} from '@app/core/builders/parserBuilders';
+
+export {
+	IElementChild,
+	IElementParent,
+} from '@app/interfaces/core/builders/parserBuilders/elements';
+
+export { IParse } from '@app/interfaces/core/builders/parserBuilders/parse';
+
+export {
+	IParseHandler,
+	IParseHandlerOutput,
+} from '@app/interfaces/core/builders/parserBuilders/parseHandlers';
+
+export {
+	IParserBuilderCore,
+	IParserBuilderCoreInput,
+	IParserBuilderCoreOutput,
+	IParserBuilderIter,
+	IParserBuilderIterInput,
+	IParserBuilderIterOutput,
+} from '@app/interfaces/core/builders/parserBuilders';

--- a/src/interfaces/core/builders/parserBuilders/IParserBuilder.ts
+++ b/src/interfaces/core/builders/parserBuilders/IParserBuilder.ts
@@ -1,6 +1,0 @@
-import { IParserBuilderInput } from './IParserBuilderInput';
-import { IParserBuilderOutput } from './IParserBuilderOutput';
-
-export interface IParserBuilder {
-	(args: IParserBuilderInput): IParserBuilderOutput;
-}

--- a/src/interfaces/core/builders/parserBuilders/IParserBuilderCore.ts
+++ b/src/interfaces/core/builders/parserBuilders/IParserBuilderCore.ts
@@ -1,0 +1,6 @@
+import { IParserBuilderCoreInput } from './IParserBuilderCoreInput';
+import { IParserBuilderCoreOutput } from './IParserBuilderCoreOutput';
+
+export interface IParserBuilderCore {
+	(args: IParserBuilderCoreInput): IParserBuilderCoreOutput;
+}

--- a/src/interfaces/core/builders/parserBuilders/IParserBuilderCoreInput.ts
+++ b/src/interfaces/core/builders/parserBuilders/IParserBuilderCoreInput.ts
@@ -1,9 +1,9 @@
 import { ParserTypeEnum } from '@app/config/enums';
 import { IElementName } from '@app/interfaces/core/builders/parserBuilders/elements';
-import { IParse } from '@app/interfaces/core/builders/parserBuilders/parse';
+import { IParseHandler } from '@app/interfaces/core/builders/parserBuilders/parseHandlers';
 
-export interface IParserBuilderOutput {
-	parse: IParse;
+export interface IParserBuilderCoreInput {
 	elName: IElementName;
+	parseHandler: IParseHandler;
 	parserType?: ParserTypeEnum;
 }

--- a/src/interfaces/core/builders/parserBuilders/IParserBuilderCoreOutput.ts
+++ b/src/interfaces/core/builders/parserBuilders/IParserBuilderCoreOutput.ts
@@ -1,9 +1,9 @@
 import { ParserTypeEnum } from '@app/config/enums';
 import { IElementName } from '@app/interfaces/core/builders/parserBuilders/elements';
-import { IParseHandler } from '@app/interfaces/core/builders/parserBuilders/parseHandlers';
+import { IParse } from '@app/interfaces/core/builders/parserBuilders/parse';
 
-export interface IParserBuilderInput {
+export interface IParserBuilderCoreOutput {
+	parse: IParse;
 	elName: IElementName;
-	parseHandler: IParseHandler;
 	parserType?: ParserTypeEnum;
 }

--- a/src/interfaces/core/builders/parserBuilders/IParserBuilderIter.ts
+++ b/src/interfaces/core/builders/parserBuilders/IParserBuilderIter.ts
@@ -1,0 +1,6 @@
+import { IParserBuilderIterInput } from './IParserBuilderIterInput';
+import { IParserBuilderIterOutput } from './IParserBuilderIterOutput';
+
+export interface IParserBuilderIter {
+	(args: IParserBuilderIterInput): IParserBuilderIterOutput;
+}

--- a/src/interfaces/core/builders/parserBuilders/IParserBuilderIterInput.ts
+++ b/src/interfaces/core/builders/parserBuilders/IParserBuilderIterInput.ts
@@ -1,0 +1,5 @@
+import { IParserBuilderCoreOutput } from './IParserBuilderCoreOutput';
+
+export interface IParserBuilderIterInput {
+	childParser: IParserBuilderCoreOutput;
+}

--- a/src/interfaces/core/builders/parserBuilders/IParserBuilderIterOutput.ts
+++ b/src/interfaces/core/builders/parserBuilders/IParserBuilderIterOutput.ts
@@ -1,0 +1,3 @@
+import { IParserBuilderCoreOutput } from './IParserBuilderCoreOutput';
+
+export type IParserBuilderIterOutput = IParserBuilderCoreOutput;

--- a/src/interfaces/core/builders/parserBuilders/index.ts
+++ b/src/interfaces/core/builders/parserBuilders/index.ts
@@ -1,1 +1,6 @@
-export { IParserBuilder } from './IParserBuilder';
+export { IParserBuilderCore } from './IParserBuilderCore';
+export { IParserBuilderCoreInput } from './IParserBuilderCoreInput';
+export { IParserBuilderCoreOutput } from './IParserBuilderCoreOutput';
+export { IParserBuilderIter } from './IParserBuilderIter';
+export { IParserBuilderIterInput } from './IParserBuilderIterInput';
+export { IParserBuilderIterOutput } from './IParserBuilderIterOutput';

--- a/src/interfaces/core/builders/parserBuilders/parseHandlers/IParseHandlerOutput.ts
+++ b/src/interfaces/core/builders/parserBuilders/parseHandlers/IParseHandlerOutput.ts
@@ -1,1 +1,3 @@
-export type IParseHandlerOutput = string | undefined | object;
+type IParseHandlerOutputBase = object | string | undefined;
+
+export type IParseHandlerOutput = IParseHandlerOutputBase | IParseHandlerOutputBase[];

--- a/test/fixtures/core/builders/parserBuilders/parserBuilderIter.positive.html
+++ b/test/fixtures/core/builders/parserBuilders/parserBuilderIter.positive.html
@@ -1,0 +1,14 @@
+<html lang="en">
+  <head>
+    <title>parserBuilderIter.positive</title>
+  </head>
+  <body>
+    <h1>parserBuilderIter.positive</h1>
+    <div class="parent">
+      <span class="child">ONE</span>
+      <span class="child">TWO</span>
+      <span class="child">THREE</span>
+      <span class="child">FOUR</span>
+    </div>
+  </body>
+</html>

--- a/test/integration/core/builders/parserBuilders/parserBuilderCore.positive.test.ts
+++ b/test/integration/core/builders/parserBuilders/parserBuilderCore.positive.test.ts
@@ -1,6 +1,4 @@
-import { parserBuilderCore } from '@dist/index';
-import { IParseHandler } from '@app/interfaces/core/builders/parserBuilders/parseHandlers';
-import { IElementParent } from '@app/interfaces/core/builders/parserBuilders/elements';
+import { parserBuilderCore, IElementParent, IParseHandler } from '@dist/index';
 import { loadPageHelper } from '@test/helpers';
 
 const path = 'core/builders/parserBuilders/parserBuilderCore.positive.html';

--- a/test/integration/core/builders/parserBuilders/parserBuilderIter.positive.test.ts
+++ b/test/integration/core/builders/parserBuilders/parserBuilderIter.positive.test.ts
@@ -1,0 +1,80 @@
+import {
+	parserBuilderIter,
+	parserBuilderLeaf,
+	parserBuilderStem,
+	IElementParent,
+	IParseHandler,
+} from '@dist/index';
+import { loadPageHelper } from '@test/helpers';
+
+const path = 'core/builders/parserBuilders/parserBuilderIter.positive.html';
+const url = `file://${global.JEST_APP_TEST_DIR}/fixtures/${path}`;
+
+const validChildParsers = [
+	{
+		name: 'parserBuilderLeaf',
+		parserBuilder: parserBuilderLeaf,
+	},
+	{
+		name: 'parserBuilderStem',
+		parserBuilder: parserBuilderStem,
+	},
+];
+
+describe('unit', () => {
+	describe('core', () => {
+		describe('builders', () => {
+			describe('parserBuilders', () => {
+				describe('parserBuilderIter', () => {
+					describe('positive', () => {
+						describe('should return the expected array of child outputs', () => {
+							test.each(validChildParsers)(
+								"when $name is passed to 'parserBuilderIter'",
+								async ({ parserBuilder }) => {
+									/*
+									 * Arrange
+									 */
+									const elNameChild = 'span.child';
+									const elNameParent = 'div.parent';
+									const numParsedChildrenExpected = 4;
+
+									/*
+									 * Arrange: child
+									 */
+									const parseHandlerChild: IParseHandler = async ({ el }) =>
+										(await el.innerText()) as string;
+									const childParser = parserBuilder({
+										elName: elNameChild,
+										parseHandler: parseHandlerChild,
+									});
+
+									/*
+									 * Arrange: elParent
+									 */
+									const page = (await loadPageHelper({
+										url,
+									})) as unknown as IElementParent;
+									const elParent = page.locator(elNameParent);
+
+									/*
+									 * Act
+									 */
+									const iterParser = parserBuilderIter({ childParser });
+									const parsedChildren = (await iterParser.parse({
+										elParent,
+									})) as string[];
+									const numParsedChildrenFound = parsedChildren.length;
+
+									/*
+									 * Assert
+									 */
+									expect(numParsedChildrenFound).toBe(numParsedChildrenExpected);
+								},
+							);
+						});
+					});
+				});
+			});
+		});
+	});
+});

--- a/test/unit/core/builders/parserBuilders/parserBuilderIter.negative.test.ts
+++ b/test/unit/core/builders/parserBuilders/parserBuilderIter.negative.test.ts
@@ -1,0 +1,42 @@
+import { parserBuilderCore, parserBuilderIter } from '@app/core/builders/parserBuilders';
+import { IParseHandler } from '@app/interfaces/core/builders/parserBuilders/parseHandlers';
+
+describe('unit', () => {
+	describe('core', () => {
+		describe('builders', () => {
+			describe('parserBuilders', () => {
+				describe('parserBuilderIter', () => {
+					describe('negative', () => {
+						describe('should throw an error', () => {
+							test("when 'childParer.parserType' is undefined", async () => {
+								/*
+								 * Arrange
+								 */
+								const elNameChild = 'span.child';
+								const errorExpected = 'Use a LEAF or a STEM child parser';
+								const parseHandlerChild: IParseHandler = async ({ el }) =>
+									(await el.innerText()) as string;
+								const childParser = parserBuilderCore({
+									elName: elNameChild,
+									parseHandler: parseHandlerChild,
+								});
+
+								/*
+								 * Act
+								 */
+								const handler = () => {
+									parserBuilderIter({ childParser });
+								};
+
+								/*
+								 * Assert
+								 */
+								expect(handler).toThrow(errorExpected);
+							});
+						});
+					});
+				});
+			});
+		});
+	});
+});

--- a/test/unit/core/builders/parserBuilders/parserBuilderIter.positive.test.ts
+++ b/test/unit/core/builders/parserBuilders/parserBuilderIter.positive.test.ts
@@ -1,0 +1,80 @@
+import {
+	parserBuilderLeaf,
+	parserBuilderStem,
+	parserBuilderIter,
+} from '@app/core/builders/parserBuilders';
+import { IParseHandler } from '@app/interfaces/core/builders/parserBuilders/parseHandlers';
+import { IElementParent } from '@app/interfaces/core/builders/parserBuilders/elements';
+import { loadPageHelper } from '@test/helpers';
+
+const path = 'core/builders/parserBuilders/parserBuilderIter.positive.html';
+const url = `file://${global.JEST_APP_TEST_DIR}/fixtures/${path}`;
+
+const validChildParsers = [
+	{
+		name: 'parserBuilderLeaf',
+		parserBuilder: parserBuilderLeaf,
+	},
+	{
+		name: 'parserBuilderStem',
+		parserBuilder: parserBuilderStem,
+	},
+];
+
+describe('unit', () => {
+	describe('core', () => {
+		describe('builders', () => {
+			describe('parserBuilders', () => {
+				describe('parserBuilderIter', () => {
+					describe('positive', () => {
+						describe('should return the expected array of child outputs', () => {
+							test.each(validChildParsers)(
+								"when $name is passed to 'parserBuilderIter'",
+								async ({ parserBuilder }) => {
+									/*
+									 * Arrange
+									 */
+									const elNameChild = 'span.child';
+									const elNameParent = 'div.parent';
+									const numParsedChildrenExpected = 4;
+
+									/*
+									 * Arrange: child
+									 */
+									const parseHandlerChild: IParseHandler = async ({ el }) =>
+										(await el.innerText()) as string;
+									const childParser = parserBuilder({
+										elName: elNameChild,
+										parseHandler: parseHandlerChild,
+									});
+
+									/*
+									 * Arrange: elParent
+									 */
+									const page = (await loadPageHelper({
+										url,
+									})) as unknown as IElementParent;
+									const elParent = page.locator(elNameParent);
+
+									/*
+									 * Act
+									 */
+									const iterParser = parserBuilderIter({ childParser });
+									const parsedChildren = (await iterParser.parse({
+										elParent,
+									})) as string[];
+									const numParsedChildrenFound = parsedChildren.length;
+
+									/*
+									 * Assert
+									 */
+									expect(numParsedChildrenFound).toBe(numParsedChildrenExpected);
+								},
+							);
+						});
+					});
+				});
+			});
+		});
+	});
+});


### PR DESCRIPTION
## Overview

The primary new code modules contained with this PR are as follows:
- `./src/core/builders/parserBuilders/parserBuilderIter.ts`
- `./src/core/builders/parserBuilders/parserBuilderLeaf.ts`
- `./src/core/builders/parserBuilders/parserBuilderStem.ts`

The units tests associated with the listed modules can be found within:
- `./test/unit/core/builders/parserBuilders/parserBuilderIter.negative.ts`
- `./test/unit/core/builders/parserBuilders/parserBuilderIter.positive.ts`

Lastly, the new integration test can be found at the following path:
- `./test/integration/core/builders/parserBuilders/parserBuilderIter.positive.ts`

## Testing
- Both sets of tests were run successfully, and the unit tests provided 100% coverage.

## Additional changes
- Several small updates were made to the `./package.json` file, such as the inclusion of a *keywords* element.
